### PR TITLE
Removed ANSI output from codeception as this was confusing the parser

### DIFF
--- a/codeception.plugin.zsh
+++ b/codeception.plugin.zsh
@@ -2,7 +2,7 @@
 
 # Functions
 _codeception_get_command_list () {
-    vendor/bin/codecept \
+    vendor/bin/codecept --no-ansi \
     	| sed "1,/Available commands/d" \
     	| awk '/^  [a-z]+/ { print $1 }'
 }


### PR DESCRIPTION
... At least on OSX, if codeception was running with ANSI output then the output parsing was getting mixed up.  
